### PR TITLE
No check needed. Parsing will throw an error if base64 is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
-# JWT Valid
+# Is JWT Valid
 > Pass a JWT token and get a boolean if the token is valid, the requirements for a valid token are defined by the official [RFC 7519 standard](https://tools.ietf.org/html/rfc7519)
 
 [![Zero Dependencies](https://img.shields.io/badge/zero-dependencies-brightgreen.svg)]()
-[![Coverage Status](https://coveralls.io/repos/github/entwicklerstube/jwt-valid/badge.svg?branch=master)](https://coveralls.io/github/entwicklerstube/jwt-valid?branch=master)
-[![Build Status](https://travis-ci.org/entwicklerstube/jwt-valid.svg?branch=master)](https://travis-ci.org/entwicklerstube/jwt-valid)
-[![devDependencies Status](https://david-dm.org/entwicklerstube/jwt-valid/dev-status.svg)](https://david-dm.org/entwicklerstube/jwt-valid?type=dev)
 
 ### Install
 **npm**
 ```
-npm install jwt-valid
+npm install is-jwt-valid
 ```
 
 **yarn**
 ```
-yarn add jwt-valid
+yarn add is-jwt-valid
 ```
 
 ### Usage
 ```js
-jwtValid(JWT_TOKEN<STRING>)
+isJwtValid(JWT_TOKEN<STRING>)
 ```
 
 ### Example
 ```js
-jwtValid('this is no valid token') // returns false
-jwtValid('some.valid.token')   // returns true
+isJwtValid('this is no valid token') // returns false
+isJwtValid('some.valid.token')   // returns true
 ```
 
 ### Support

--- a/index.js
+++ b/index.js
@@ -1,18 +1,11 @@
 export const parseBase64ByPlattform = base64String => {
-  if (!base64String || !isValidBase64(base64String)) throw new Error('No valid base64 passed')
+  if (!base64String) throw new Error('No valid base64 passed')
 
   if (typeof window === 'undefined' && (process && process.version !== 'undefined')) {
     return Buffer.from(base64String, 'base64').toString()
   } else {
     return window.atob(base64String)
   }
-}
-
-export const isValidBase64 = base64String => {
-  if (!base64String) return false
-  if (!(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(base64String))) return false
-
-  return true
 }
 
 export const parseJwtToken = jwtToken => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "is-jwt-valid",
   "version": "1.0.0",
   "description": "Pass a jwt token and get a boolean if the token is valid",
-  "keywords": "jwt, jwt valid, jwt still valid, valid, valid",
+  "keywords": ["jwt", "jwt valid", "jwt still valid", "valid"],
   "main": "index.js",
   "repository": "https://github.com/levinunnink/jwt-valid",
   "author": "Michael J. Zoidl",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,19 @@
 {
-  "name": "jwt-valid",
-  "version": "1.1.0",
+  "name": "is-jwt-valid",
+  "version": "1.0.0",
   "description": "Pass a jwt token and get a boolean if the token is valid",
   "keywords": "jwt, jwt valid, jwt still valid, valid, valid",
-  "main": "build/index.js",
-  "repository": "https://github.com/entwicklerstube/jwt-valid",
+  "main": "index.js",
+  "repository": "https://github.com/levinunnink/jwt-valid",
   "author": "Michael J. Zoidl",
   "license": "MIT",
   "scripts": {
     "build": "rimraf build && mkdir build && babel index.js --out-dir build",
-    "prepublish": "yarn run standard && yarn run test && yarn run build",
+    "prepublish": "npm run-script standard && npm run-script test && npm run-script build",
     "test": "mocha test.js --require mocha --compilers js:babel-core/register",
     "standard": "standard --env mocha",
     "nyc": "nyc --require babel-core/register --require './mocha.js' mocha test.js",
-    "coverage": "yarn run nyc && nyc report --reporter=text-lcov | coveralls",
-    "prepublish": "yarn run test && yarn run build"
+    "coverage": "npm run-script nyc && nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
     "build"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "is-jwt-valid",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pass a jwt token and get a boolean if the token is valid",
   "keywords": ["jwt", "jwt valid", "jwt still valid", "valid"],
-  "main": "index.js",
+  "main": "build/index.js",
   "repository": "https://github.com/levinunnink/jwt-valid",
   "author": "Michael J. Zoidl",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-jwt-valid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pass a jwt token and get a boolean if the token is valid",
   "keywords": ["jwt", "jwt valid", "jwt still valid", "valid"],
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -3,16 +3,6 @@ import { parseBase64ByPlattform, isValidBase64, parseJwtToken } from './index'
 const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqd3QiOiJpcyBhd2Vzb21lISJ9.j8Z3twgi5nCrZJXH1JoxfQ8q1u5btwr3vS3wyqfytOo'
 
 describe('JWT Valid', () => {
-  describe('isValidBase64', () => {
-    it('returns false if a not valid base64 string is passed', () => {
-      expect(isValidBase64('No Valid Base64 String')).to.equal(false)
-    })
-
-    it('returns true if a valid base64 string is passed', () => {
-      expect(isValidBase64('SSBhbSB2YWxpZA==')).to.equal(true)
-    })
-  })
-
   describe('parseBase64ByPlattform', () => {
     it('returns error if no valid token is passed', () => {
       expect(() => parseBase64ByPlattform()).to.throw('No valid base64 passed')

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import { parseBase64ByPlattform, isValidBase64, parseJwtToken } from './index'
+import { parseBase64ByPlattform, parseJwtToken } from './index'
 
 const jwtToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqd3QiOiJpcyBhd2Vzb21lISJ9.j8Z3twgi5nCrZJXH1JoxfQ8q1u5btwr3vS3wyqfytOo'
 


### PR DESCRIPTION
We don't actually need to run the regex check on the base64 string. 

1. It was failing on a valid base64 string for me.
2. The `window.atob` or the `Buffer.from` will both throw errors if the string is invalid and the `parseJwtToken` will return false.

By removing this, we don't get any invalid results on valid jwt tokens. 